### PR TITLE
feat: Make OpenCL testing in GPU CI workflows optional

### DIFF
--- a/.github/workflows/gpu-bench.yml
+++ b/.github/workflows/gpu-bench.yml
@@ -1,7 +1,7 @@
 # Run final tests only when attempting to merge, shown as skipped status checks beforehand
 # Prerequisites
 # - Self-hosted Nvidia GPU runner with `gpu-bench` tag in caller repo
-# - `cuda` and `opencl` Cargo features
+# - `cuda` Cargo features
 # - Pre-existing `gh-pages` branch
 # - Run on `merge_group` trigger only
 name: Comparative benchmarks on GPU

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -9,6 +9,10 @@ on:
   # if: github.event_name != 'pull_request' || github.event.action == 'enqueued'
   workflow_call:
     inputs:
+      opencl:
+        required: false
+        type: boolean
+        default: false
       # comma-separated list of features to run in addition to `cuda`/`opencl`
       features:
         required: false
@@ -39,6 +43,7 @@ jobs:
 
   opencl:
     name: Rust tests on OpenCL
+    if: ${{ inputs.opencl }}
     runs-on: [self-hosted, gpu-ci]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Modified GPU benchmarking and CI testing workflows in GitHub Actions.
- Removed `opencl` feature requirement in GPU benchmark workflow.
- Introduced an optional 'opencl' input parameter in the GPU CI Tests workflow.
- Made the execution of 'Rust tests on OpenCL' job conditionally dependent on the new 'opencl' input.