### PR TITLE
fix: `rust-version-check.yml`

### DIFF
--- a/.github/workflows/rust-version-check.yml
+++ b/.github/workflows/rust-version-check.yml
@@ -23,7 +23,7 @@ jobs:
         id: parse-toolchain
         run: |
           CHANNEL=$(awk -F'\"' '/channel/ {print $2}' rust-toolchain.toml)
-          if [[ $CHANNEL =~ ^[0-9]+\.[0-9]+$ ]]; then
+          if [[ $CHANNEL =~ ^[0-9]+\.[0-9]+(\.[0-9])?$ ]]; then
             echo "TOOLCHAIN_VERSION=$CHANNEL" >> $GITHUB_ENV
           else
             echo "TOOLCHAIN_VERSION=stable" >> $GITHUB_ENV

--- a/.github/workflows/rust-version-check.yml
+++ b/.github/workflows/rust-version-check.yml
@@ -1,3 +1,4 @@
+# Checks whether Rust version specified in `rust-toolchain.toml` is out of date with latest stable
 name: Rust Version Check
 
 
@@ -14,9 +15,9 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Get Local Rust Version
+      - name: Get latest stable Rust version
         id: get-rust-version
-        run: echo "RUST_VERSION=$(rustc --version | awk '{print $2}')" >> $GITHUB_ENV
+        run: echo "RUST_VERSION=$(rustup check | grep stable | awk '{print $(NF-2)}')" >> $GITHUB_ENV
 
       - name: Parse rust-toolchain.toml
         id: parse-toolchain
@@ -28,7 +29,7 @@ jobs:
             echo "TOOLCHAIN_VERSION=stable" >> $GITHUB_ENV
           fi
 
-      - name: Compare Rust Versions
+      - name: Compare Rust versions
         id: compare-versions
         run: |
           if [[ $TOOLCHAIN_VERSION != "stable" && $TOOLCHAIN_VERSION < $RUST_VERSION ]]; then


### PR DESCRIPTION
Fixes #23 by using `rustup check` to get the latest Rust stable release.

- The `awk` script parses correctly with both an up-to-date local installation or an out-of-date one (the former was tested locally only). 
- Also enables an optional `patch` specifier e.g. in `1.70.0` rather than just `major.minor`

Successful run (expand the failing step to see the correct env values for `$RUST_VERSION` and `$TOOLCHAIN_VERSION`: https://github.com/lurk-lab/ci-lab/actions/runs/7535003798/job/20510418363