### PR TITLE
Add typo checker workflow

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,60 @@
+name: Check for typos
+
+on:
+  # Supported triggers:
+  # `workflow_dispatch` and nightly, e.g.:
+  # schedule:
+  #  - cron: "0 0 * * *"
+  workflow_call:
+
+jobs:
+  typo-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install typos binary
+        run: cargo +stable install typos-cli
+      - name: Check typos and write suggestions
+        id: typo-check
+        run: |
+          typos --write-changes > _typos.txt || true
+          if [[ `git status --porcelain --untracked-files=no` ]]; then
+            echo "typos=true" | tee -a $GITHUB_OUTPUT
+          else
+            echo "typos=false" | tee -a $GITHUB_OUTPUT
+          fi
+      - name: Create file for PR
+        if: steps.typo-check.outputs.typos == 'true'
+        run: |
+          printf '%s\n' "Fixes typos found by running \`typos --write-changes\`
+          Commit: ${{ github.sha }}
+          Workflow run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > _body.md
+          if [[ -s _typos.txt ]]; then
+            printf "The following typos could not be fixed:\n\`\`\`\n" >> _body.md
+            cat _typos.txt >> _body.md
+            printf "\`\`\`" >> _body.md
+          fi
+          rm _typos.txt
+      # Checks which file types should be committed with typo corrections
+      # Git pathspecs cause errors if the given pattern doesn't exist, e.g. `git add -- **/*.txt` without any `.txt` files
+      - name: Check for common file types
+        if: steps.typo-check.outputs.typos == 'true'
+        id: file-types
+        run: |
+          FILE_PATHS=:!*\_body.md,$(git status --porcelain | awk -F. '{OFS=""; print "**/*."$NF}' | sort -u | paste -sd,)
+          echo "paths=$FILE_PATHS" | tee -a $GITHUB_OUTPUT
+      # Note: Doesn't work for `push` or `pull_request` triggers
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        if: steps.typo-check.outputs.typos == 'true'
+        with:
+          commit-message: '[automated] Fix typos'
+          title: '[automated] Fix typos'
+          branch: 'patch/fix-typos'
+          delete-branch: true
+          body-path: ./_body.md
+          labels: automated issue, documentation
+          # Required in order to exclude the `_body.md` file from the PR
+          add-paths: ${{ steps.file-types.outputs.paths }}


### PR DESCRIPTION
## Automated typo correction
- Checks for typos using https://github.com/crate-ci/typos/
- Opens a PR with suggestions (from the `typos --write-changes` flag), and comments the errors it can't fix in the PR description
- Updates the same PR and description with new runs while it's open

## Limitations
- If errors are detected without actionable suggestions, no PR is opened. We could make it open an issue instead or wait till a solvable typo appears and both are visible in a PR.
- There doesn't seem to be a nice PR template we can use like https://github.com/JasonEtco/create-an-issue
- Requires some Git pathspec hackery to avoid committing the PR description `body-path` file

## Successful run
https://github.com/lurk-lab/ci-lab/pull/58 (see linked workflow run)