### PR TITLE
fix: ignore patch version when comparing Rust versions

### DIFF
--- a/.github/workflows/rust-version-check.yml
+++ b/.github/workflows/rust-version-check.yml
@@ -1,7 +1,6 @@
 # Checks whether Rust version specified in `rust-toolchain.toml` is out of date with latest stable
 name: Rust Version Check
 
-
 on:
   workflow_call:
 
@@ -23,7 +22,7 @@ jobs:
 
       - name: Get latest stable Rust version
         id: get-rust-version
-        run: echo "RUST_VERSION=$(rustup check | grep stable | awk '{print $(NF-2)}')" >> $GITHUB_ENV
+        run: echo "RUST_VERSION=$(rustup check | grep stable | awk '{print $(NF-2)}'| cut -d '.' -f1,2)" >> $GITHUB_ENV
 
       - name: Parse rust-toolchain.toml
         id: parse-toolchain


### PR DESCRIPTION
- Implemented change to set TOOLCHAIN_VERSION by extracting only the major and minor version from the specified Rust version in `rust-toolchain.toml`.

This should fix https://github.com/lurk-lab/arecibo/issues/274