### PR TITLE
fix: Improve version mismatch checks

### DIFF
--- a/.github/templates/VERSION_CHECK.md
+++ b/.github/templates/VERSION_CHECK.md
@@ -3,8 +3,8 @@ title: "chore: rust toolchain needs an upgrade"
 labels: debt, automated-issues
 ---
 
-The rust version specified in `rust-toolchain.toml` is out of date with the latest stable.
+The rust version specified in `rust-toolchain.toml` ({{env.TOOLCHAIN_VERSION}}) is out of date with the latest stable ({{env.RUST_VERSION}}).
 
 Check the [rust version check]({{env.WORKFLOW_URL}}) workflow for details.
 
-This issue was raised by the workflow at `https://github.com/lurk-lab/ci-workflows/tree/main/.github/workflows/rust-version-check.yml`.
+This issue was raised by the workflow at {{env.WORKFLOW_FILE}}.

--- a/.github/workflows/rust-version-check.yml
+++ b/.github/workflows/rust-version-check.yml
@@ -1,6 +1,7 @@
 # Checks whether Rust version specified in `rust-toolchain.toml` is out of date with latest stable
+# Compares the full `<major>.<minor>.<patch>` of `rustup show` with `rustup check`
+# This is because the patch version will auto-update if unspecified in `rust-toolchain.toml`
 name: Rust Version Check
-
 
 on:
   workflow_call:
@@ -21,33 +22,29 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Get latest stable Rust version
-        id: get-rust-version
-        run: echo "RUST_VERSION=$(rustup check | grep stable | awk '{print $(NF-2)}')" >> $GITHUB_ENV
-
       - name: Parse rust-toolchain.toml
-        id: parse-toolchain
-        run: |
-          CHANNEL=$(awk -F'\"' '/channel/ {print $2}' rust-toolchain.toml)
-          if [[ $CHANNEL =~ ^[0-9]+\.[0-9]+(\.[0-9])?$ ]]; then
-            echo "TOOLCHAIN_VERSION=$CHANNEL" >> $GITHUB_ENV
-          else
-            echo "TOOLCHAIN_VERSION=stable" >> $GITHUB_ENV
-          fi
+        run: echo "TOOLCHAIN_VERSION=$(rustup show | grep rustc | awk '{ print $2 }')" | tee -a $GITHUB_ENV
+
+      - name: Get latest stable Rust version
+        run: echo "RUST_VERSION=$(rustup check | grep stable | awk '{print $(NF-2)}')" | tee -a $GITHUB_ENV
 
       - name: Compare Rust versions
-        id: compare-versions
         run: |
-          if [[ $TOOLCHAIN_VERSION != "stable" && $TOOLCHAIN_VERSION < $RUST_VERSION ]]; then
-            echo "VERSION_MISMATCH=true" >> $GITHUB_ENV
+          if [[ $TOOLCHAIN_VERSION < $RUST_VERSION ]]; then
+            echo "VERSION_MISMATCH=true" | tee -a $GITHUB_ENV
           else
-            echo "VERSION_MISMATCH=false" >> $GITHUB_ENV
+            echo "VERSION_MISMATCH=false" | tee -a $GITHUB_ENV
           fi
+
+      # Open issue if crate Rust version is out of date with latest stable
       - uses: JasonEtco/create-an-issue@v2
         if: env.VERSION_MISMATCH == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOOLCHAIN_VERSION: ${{ env.TOOLCHAIN_VERSION }}
+          RUST_VERSION: ${{ env.RUST_VERSION }}
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WORKFLOW_FILE: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/workflow
         with:
           update_existing: true
           filename: ci-workflows/.github/templates/VERSION_CHECK.md


### PR DESCRIPTION
- Gets the local Rust version by running `rustup show` instead of the specifier in `rust-toolchain.toml`. If the latter doesn't specify a patch version (e.g. 1.72), it will update to the latest toolchain patch if it exists (e.g. 1.72.1). It thus seems more robust to parse `rustup show` directly, so we always have the fully-qualified version used by the crate. Then the comparison is simple because the output of `rustup check` will also always have the patch number.
- Adds some more info to the `VERSION_CHECK.md` issue template. I'm not sure whether the workflow file linked by the workflow run is that useful, but it's the most accurate file to show aside from a separate permalink.

Successful run:
https://github.com/lurk-lab/ci-lab/issues/62
https://github.com/lurk-lab/ci-lab/actions/runs/7616695024/job/20744059559?pr=61