### PR TITLE
Add benchmark plotting crate and workflow

### DIFF
--- a/.github/workflows/bench-deploy.yml
+++ b/.github/workflows/bench-deploy.yml
@@ -1,12 +1,18 @@
 # Intended to run on the `push` trigger
+# Pre-requisites
+# - `gh-pages` branch with Pages deployment set up
+# - Ideally some HTML to link to the reports, e.g. https://lurk-lab.github.io/ci-lab/
+# - Self-hosted runner attached to the caller repo with `gpu-bench` and `gh-pages` tags
+# - `justfile` with a `gpu-bench-ci` recipe
 name: Deploy GPU benchmark from default branch
 
 on:
   workflow_call:
     inputs:
-      runner:
+      # Leave as default for lurk-rs, input `ARECIBO` for arecibo
+      env-prefix:
         required: false
-        default: 'ubuntu-latest'
+        default: 'LURK'
         type: string
 
 jobs:
@@ -29,46 +35,95 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
-          tool: just@1.15.0
-      # Set up GPU
-      # Check we have access to the machine's Nvidia drivers
-      - run: nvidia-smi
-      # Check that CUDA is installed with a driver-compatible version
-      # This must also be compatible with the GPU architecture, see above link
-      - run: nvcc --version
+          tool: just@1.22.0
       # Run benchmarks and deploy
       - name: Get old benchmarks
         uses: actions/checkout@v4
         with:
           ref: gh-pages
           path: gh-pages
-      - run: mkdir -p target; cp -r gh-pages/benchmarks/criterion target;
       - name: Install criterion
         run: cargo install cargo-criterion
+      - name: Copy old benchmarks locally for comparison
+        run: |
+          mkdir -p target gh-pages/benchmarks/criterion
+          cp -r gh-pages/benchmarks/criterion target
+      # Make sure to set repo-specific env vars in the `justfile`/`bench.env`, e.g. `LURK_RC`
+      - name: Set env vars
+        run: |
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" | tee -a $GITHUB_ENV
+          echo "${{ inputs.env-prefix }}_BENCH_OUTPUT=gh-pages" | tee -a $GITHUB_ENV
       - name: Run benchmarks
         run: |
-          just --dotenv-filename bench.env gpu-bench fibonacci
-          cp ${{ github.sha }}.json ..
+          just gpu-bench-ci fibonacci
+          mv fibonacci-${{ env.SHORT_SHA }}.json ..
         working-directory: ${{ github.workspace }}/benches
+      # If no plot data found, unzip all historical bench results and re-create the plots
+      # TODO: Fix the error when no tarballs are found rather than `continue-on-error`
+      - name: Check for existing plot data
+        run: |
+          if [ ! -f "plot-data.json" ]; then
+            cat gh-pages/benchmarks/history/*.tar.gz | tar -xvzf - -i
+          fi
+        continue-on-error: true
+      # TODO: This should probably be in a subdirectory or Cargo workspace
+      # Saves the plot data to be deployed
+      - name: Generate historical performance plot
+        run: |
+          cargo run
+          mkdir -p history
+          mv -f plot-data.json history
       # TODO: Prettify labels for easier viewing
       # Compress the benchmark file and metadata for later analysis
       - name: Compress artifacts
         run: |
           echo $LABELS > labels.md
-          tar -cvzf ${{ github.sha }}.tar.gz Cargo.lock ${{ github.sha }}.json labels.md
+          tar -cvzf fibonacci-${{ env.SHORT_SHA }}.tar.gz Cargo.lock fibonacci-${{ env.SHORT_SHA }}.json labels.md
+          mv -f fibonacci-${{ env.SHORT_SHA }}.tar.gz history
         working-directory: ${{ github.workspace }}
+      # TODO: Arguably the HTML template should be a pre-requisite
+      - name: Prepare HTML plots page
+        run: |
+          if [[ ! -f plots.html ]]; then
+            html=$(cat << EOF
+          <!DOCTYPE html>
+          <html>
+          <head>
+          <style>
+          img {
+            width: 100%;
+          }
+          </style>
+          </head>
+          <body>
+          </body>
+          </html>
+          EOF
+          )
+            echo "$html" > plots.html
+          fi
+
+          shopt -s nullglob  # Prevent errors if no matching files are found
+
+          for FILE in `ls *.png | sort -g`; do
+             if [[ -f $FILE ]]; then # Check if it's a regular file
+                 IMAGE="<img src=\"$FILE\" alt=\"Benchmark history plot for $FILE\" style=\"width:1000px;height:1000px;\"/>"
+                 echo $IMAGE
+                 sed -i "/<\/body>/i\\$IMAGE" plots.html
+             fi
+          done
+
+          mv -f *.png plots.html history
       - name: Deploy latest benchmark report
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/criterion
           destination_dir: benchmarks/criterion
-      - name: Copy benchmark json to history
-        run: mkdir history; cp ${{ github.sha }}.tar.gz history/
       - name: Deploy benchmark history
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: history/
+          publish_dir: ./history
           destination_dir: benchmarks/history
           keep_files: true

--- a/.github/workflows/bench-deploy.yml
+++ b/.github/workflows/bench-deploy.yml
@@ -3,7 +3,7 @@
 # - `gh-pages` branch with Pages deployment set up
 # - Ideally some HTML to link to the reports, e.g. https://lurk-lab.github.io/ci-lab/
 # - Self-hosted runner attached to the caller repo with `gpu-bench` and `gh-pages` tags
-# - `justfile` with a `gpu-bench-ci` recipe
+# - `justfile` with a `gpu-bench-ci` recipe that outputs `<bench-name>-<short-sha>.json`
 name: Deploy GPU benchmark from default branch
 
 on:
@@ -16,8 +16,6 @@ on:
         type: string
 
 jobs:
-  # One option is to upload them to gh-pages for qualitative comparison
-  # TODO: Fall back to a default if `justfile`/`bench.env` not present
   benchmark:
     name: Bench and deploy
     runs-on: [self-hosted, gpu-bench, gh-pages]
@@ -51,21 +49,26 @@ jobs:
       # Make sure to set repo-specific env vars in the `justfile`/`bench.env`, e.g. `LURK_RC`
       - name: Set env vars
         run: |
-          echo "SHORT_SHA=$(git rev-parse --short HEAD)" | tee -a $GITHUB_ENV
+          echo "COMMIT=$(git rev-parse --short HEAD)" | tee -a $GITHUB_ENV
           echo "${{ inputs.env-prefix }}_BENCH_OUTPUT=gh-pages" | tee -a $GITHUB_ENV
       - name: Run benchmarks
         run: |
           just gpu-bench-ci fibonacci
-          mv fibonacci-${{ env.SHORT_SHA }}.json ..
+          mv fibonacci-${{ env.COMMIT }}.json ..
         working-directory: ${{ github.workspace }}/benches
-      # If no plot data found, unzip all historical bench results and re-create the plots
-      # TODO: Fix the error when no tarballs are found rather than `continue-on-error`
+      # If no plot data found, unzip all historical bench results to re-create the plots
       - name: Check for existing plot data
         run: |
           if [ ! -f "plot-data.json" ]; then
-            cat gh-pages/benchmarks/history/*.tar.gz | tar -xvzf - -i
+            shopt -s nullglob # Make glob patterns that match no files expand to a null string
+            tarballs=(./*.tar.gz)
+            if (( ${#tarballs[@]} )); then
+              cat "${tarballs[@]}" | tar -xvzf - -i
+            else
+              echo "No tarballs found for extraction."
+            fi
+            shopt -u nullglob # Disable nullglob option
           fi
-        continue-on-error: true
       # TODO: This should probably be in a subdirectory or Cargo workspace
       # Saves the plot data to be deployed
       - name: Generate historical performance plot
@@ -78,8 +81,8 @@ jobs:
       - name: Compress artifacts
         run: |
           echo $LABELS > labels.md
-          tar -cvzf fibonacci-${{ env.SHORT_SHA }}.tar.gz Cargo.lock fibonacci-${{ env.SHORT_SHA }}.json labels.md
-          mv -f fibonacci-${{ env.SHORT_SHA }}.tar.gz history
+          tar -cvzf fibonacci-${{ env.COMMIT }}.tar.gz Cargo.lock fibonacci-${{ env.COMMIT }}.json labels.md
+          mv -f fibonacci-${{ env.COMMIT }}.tar.gz history
         working-directory: ${{ github.workspace }}
       # TODO: Arguably the HTML template should be a pre-requisite
       - name: Prepare HTML plots page

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "benchmark-plotter"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0"
+# chrono version is pinned to be compatible with plotters `build_cartesian_2d` API
+chrono = { version = "=0.4.20", features = ["clock", "serde"] }
+plotters = "0.3.5"
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.111"
+
+[dev-dependencies]
+criterion = "0.4"
+anyhow = "1.0"
+
+[build-dependencies]
+vergen = { version = "8", features = ["build", "git", "gitcl"] }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+use std::error::Error;
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Emit the instructions
+    EmitBuilder::builder().all_git().emit()?;
+    Ok(())
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.75.0"
+targets = [ "wasm32-unknown-unknown" ]
+profile = "default"

--- a/src/json.rs
+++ b/src/json.rs
@@ -1,0 +1,147 @@
+use core::fmt;
+use std::io::Read;
+use std::{fs::File, path::Path};
+
+use serde::Deserialize;
+use serde_json::de::{StrRead, StreamDeserializer};
+use serde_json::{Deserializer, Error, Value};
+
+#[derive(Debug, Deserialize)]
+pub struct BenchData {
+    pub id: BenchId,
+    #[serde(rename = "typical")]
+    pub result: BenchResult,
+}
+
+#[derive(Debug)]
+pub struct BenchId {
+    pub group_name: String,
+    pub bench_name: String,
+    pub params: String,
+}
+
+// Assumes three `String` elements in a Criterion bench ID: <group>/<name>/<params>
+// E.g. `Fibonacci-num=10/28db40f-2024-01-30T19:07:04-05:00/rc=100`
+// Errors if a different format is found
+impl<'de> Deserialize<'de> for BenchId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        let id = s.split('/').collect::<Vec<&str>>();
+        if id.len() != 3 {
+            Err(serde::de::Error::custom("Expected 3 bench ID elements"))
+        } else {
+            let bench_name = id[1].replace('_', ":");
+            Ok(BenchId {
+                group_name: id[0].to_owned(),
+                // Criterion converts `:` to `_` in the timestamp as the former is valid JSON syntax,
+                // so we convert `_` back to `:` when deserializing
+                bench_name,
+                params: id[2].to_owned(),
+            })
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BenchResult {
+    #[serde(rename = "estimate")]
+    pub time: f64,
+}
+
+// Deserializes the benchmark JSON file into structured data for plotting
+pub fn read_json_from_file<P: AsRef<Path>>(path: P) -> Result<Vec<BenchData>, Error> {
+    let mut file = File::open(path).unwrap();
+    let mut s = String::new();
+    file.read_to_string(&mut s).unwrap();
+
+    let mut data = vec![];
+    for result in ResilientStreamDeserializer::<BenchData>::new(&s).flatten() {
+        data.push(result);
+    }
+    Ok(data)
+}
+
+// The following code is taken from https://users.rust-lang.org/t/step-past-errors-in-serde-json-streamdeserializer/84228/10
+// The `ResilientStreamDeserializer` is a workaround to enable a `StreamDeserializer` to continue parsing when it encounters
+// a deserialization type error or invalid JSON. See https://github.com/serde-rs/json/issues/70 for discussion
+#[derive(Debug)]
+pub struct JsonError {
+    error: Error,
+    value: Option<Value>, // Some(_) if JSON was syntactically valid
+}
+
+impl fmt::Display for JsonError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.error)?;
+
+        if let Some(value) = self.value.as_ref() {
+            write!(formatter, ", value: {}", value)?;
+        }
+
+        Ok(())
+    }
+}
+
+impl std::error::Error for JsonError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
+}
+
+pub struct ResilientStreamDeserializer<'de, T> {
+    json: &'de str,
+    stream: StreamDeserializer<'de, StrRead<'de>, T>,
+    last_ok_pos: usize,
+}
+
+impl<'de, T> ResilientStreamDeserializer<'de, T>
+where
+    T: Deserialize<'de>,
+{
+    pub fn new(json: &'de str) -> Self {
+        let stream = Deserializer::from_str(json).into_iter();
+        let last_ok_pos = 0;
+
+        ResilientStreamDeserializer {
+            json,
+            stream,
+            last_ok_pos,
+        }
+    }
+}
+
+impl<'de, T> Iterator for ResilientStreamDeserializer<'de, T>
+where
+    T: Deserialize<'de>,
+{
+    type Item = Result<T, JsonError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.stream.next()? {
+            Ok(value) => {
+                self.last_ok_pos = self.stream.byte_offset();
+                Some(Ok(value))
+            }
+            Err(error) => {
+                // If an error happened, check whether it's a type error, i.e.
+                // whether the next thing in the stream was at least valid JSON.
+                // If so, return it as a dynamically-typed `Value` and skip it.
+                let err_json = &self.json[self.last_ok_pos..];
+                let mut err_stream = Deserializer::from_str(err_json).into_iter::<Value>();
+                let value = err_stream.next()?.ok();
+                let next_pos = if value.is_some() {
+                    self.last_ok_pos + err_stream.byte_offset()
+                } else {
+                    self.json.len() // when JSON has a syntax error, prevent infinite stream of errors
+                };
+                self.json = &self.json[next_pos..];
+                self.stream = Deserializer::from_str(self.json).into_iter();
+                self.last_ok_pos = 0;
+                Some(Err(JsonError { error, value }))
+            }
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,114 @@
+mod json;
+mod plot;
+
+use std::{
+    io::{self, Read, Write},
+    path::PathBuf,
+};
+
+use anyhow::anyhow;
+use json::read_json_from_file;
+
+use crate::plot::{generate_plots, Plots};
+
+// TODO: Switch to camino
+// Gets all JSON paths in the current directory, optionally ending in a given suffix
+// E.g. if `suffix` is `abc1234.json` it will return "*abc1234.json"
+fn get_json_paths(suffix: Option<&str>) -> std::io::Result<Vec<std::path::PathBuf>> {
+    let suffix = suffix.unwrap_or(".json");
+    let entries = std::fs::read_dir(".")?
+        .flatten()
+        .filter_map(|e| {
+            let ext = e.path();
+            if ext.to_str()?.ends_with(suffix) {
+                Some(ext)
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    Ok(entries)
+}
+
+// Benchmark files to plot, e.g. `LURK_BENCH_FILES=fibonacci-abc1234,fibonacci-def5678`
+fn bench_files_env() -> anyhow::Result<Vec<String>> {
+    std::env::var("LURK_BENCH_FILES")
+        .map_err(|e| anyhow!("Benchmark files env var isn't set: {e}"))
+        .and_then(|commits| {
+            let vec: anyhow::Result<Vec<String>> = commits
+                .split(',')
+                .map(|sha| {
+                    sha.parse::<String>()
+                        .map_err(|e| anyhow!("Failed to parse Git commit string: {e}"))
+                })
+                .collect();
+            vec
+        })
+}
+
+// Deserializes JSON file into `Plots` type
+fn read_plots_from_file() -> Result<Plots, io::Error> {
+    let path = std::path::Path::new("plot-data.json");
+
+    let mut file = std::fs::File::open(path)?;
+
+    let mut s = String::new();
+    file.read_to_string(&mut s)?;
+
+    let plots: Plots = serde_json::from_str(&s)?;
+
+    Ok(plots)
+}
+
+// Serializes `Plots` type into file
+fn write_plots_to_file(plot_data: &Plots) -> Result<(), io::Error> {
+    let path = std::path::Path::new("plot-data.json");
+
+    let mut file = std::fs::File::create(path)?;
+
+    let json_data = serde_json::to_string(&plot_data)?;
+
+    file.write_all(json_data.as_bytes())
+}
+
+fn main() {
+    // If existing plot data is found on disk, only read and add benchmark files specified by `LURK_BENCH_FILES`
+    // Data is stored in a `HashMap` so duplicates are ignored
+    let (mut plots, bench_files) = {
+        if let Ok(plots) = read_plots_from_file() {
+            // The user should know which files they just benchmarked and want to add to the plot
+            // Otherwise defaults to all files containing the current Git commit
+            let bench_files = bench_files_env().map_or_else(
+                |_| {
+                    let mut short_sha = env!("VERGEN_GIT_SHA").to_owned();
+                    short_sha.truncate(7);
+                    get_json_paths(Some(&format!("{}.json", short_sha)))
+                        .expect("Failed to read JSON paths")
+                },
+                |files| {
+                    files
+                        .iter()
+                        .map(|file| PathBuf::from(format!("{}.json", file)))
+                        .collect()
+                },
+            );
+            (plots, bench_files)
+        }
+        // If no plot data exists, read all `JSON` files in the current directory and save to disk
+        else {
+            let paths = get_json_paths(None).expect("Failed to read JSON paths");
+            (Plots::new(), paths)
+        }
+    };
+    println!("Adding bench files to plot: {:?}", bench_files);
+    let mut bench_data = vec![];
+    for file in bench_files {
+        let mut data = read_json_from_file(file).expect("JSON serde error");
+        bench_data.append(&mut data);
+    }
+    plots.add_data(&bench_data);
+
+    // Write to disk
+    write_plots_to_file(&plots).expect("Failed to write `Plots` to `plot-data.json`");
+    generate_plots(&plots).unwrap();
+}

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -1,0 +1,235 @@
+use plotters::prelude::*;
+
+use chrono::{serde::ts_seconds, DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+
+use std::{collections::HashMap, error::Error};
+
+use crate::json::BenchData;
+
+// TODO: Figure out how to include the commit hash as a label on the point or X-axis
+pub fn generate_plots(data: &Plots) -> Result<(), Box<dyn Error>> {
+    for plot in data.0.iter() {
+        let out_file_name = format!("./{}.png", plot.0);
+        let root = BitMapBackend::new(&out_file_name, (1024, 768)).into_drawing_area();
+        root.fill(&WHITE)?;
+
+        let mut chart = ChartBuilder::on(&root)
+            .margin(10)
+            .caption(plot.0, ("sans-serif", 40))
+            .set_label_area_size(LabelAreaPosition::Left, 60)
+            .set_label_area_size(LabelAreaPosition::Bottom, 40)
+            .build_cartesian_2d(
+                // Add one day buffer before and after
+                plot.1
+                    .x_axis
+                    .min
+                    .checked_sub_signed(Duration::days(1))
+                    .expect("DateTime underflow")
+                    ..plot
+                        .1
+                        .x_axis
+                        .max
+                        .checked_add_signed(Duration::days(1))
+                        .expect("DateTime overflow"),
+                // Add 0.2 ns buffer before and after (not rigorous, based on a priori knowledge of Y axis units & values)
+                plot.1.y_axis.min - 0.2f64..plot.1.y_axis.max + 0.2f64,
+            )?;
+
+        chart
+            .configure_mesh()
+            .disable_x_mesh()
+            .disable_y_mesh()
+            .x_labels(10)
+            .max_light_lines(4)
+            .x_desc("Commit Date")
+            .y_desc("Time (ns)")
+            .draw()?;
+
+        // Draws the lines of benchmark data points, one line/color per set of bench ID params e.g. `rc=100`
+        for (i, line) in plot.1.lines.iter().enumerate() {
+            // Draw lines between each point
+            chart
+                .draw_series(LineSeries::new(
+                    line.1.iter().map(|p| (p.x, p.y)),
+                    Palette99::pick(i),
+                ))?
+                .label(line.0)
+                // TODO: Move the legend out of the plot area
+                .legend(move |(x, y)| {
+                    Rectangle::new(
+                        [(x - 5, y - 5), (x + 5, y + 5)],
+                        Palette99::pick(i).filled(),
+                    )
+                });
+
+            // Draw dots on each point
+            chart.draw_series(
+                line.1
+                    .iter()
+                    .map(|p| Circle::new((p.x, p.y), 3, Palette99::pick(i).filled())),
+            )?;
+            chart
+                .configure_series_labels()
+                .background_style(WHITE)
+                .border_style(BLACK)
+                .draw()?;
+        }
+
+        // To avoid the IO failure being ignored silently, we manually call the present function
+        root.present().expect("Unable to write result to file");
+        println!("Result has been saved to {}", out_file_name);
+    }
+
+    Ok(())
+}
+
+// Convert <short-sha>-<commit-date> to a `DateTime` object, discarding `short-sha`
+fn str_to_datetime(input: &str) -> Result<DateTime<Utc>, Box<dyn Error>> {
+    // Removes the first 8 chars (assuming UTF8) for the `short-sha` and trailing '-'
+    let datetime: &str = input.split_at(8).1;
+
+    DateTime::parse_from_rfc3339(datetime).map_or_else(
+        |e| Err(format!("Failed to parse string into `DateTime`: {}", e).into()),
+        |dt| Ok(dt.with_timezone(&Utc)),
+    )
+}
+
+// Plots of benchmark results over time/Git history. This data structure is persistent between runs,
+// saved to disk in `plot-data.json`, and is meant to be append-only to preserve historical results.
+//
+// Note:
+// Plots are separated by benchmark input e.g. `Fibonacci-num-100`. It doesn't reveal much
+// information to view multiple benchmark input results on the same graph (e.g. fib-10 and fib-20),
+// since they are expected to be different. Instead, we group different benchmark parameters
+// (e.g. `rc` value) onto the same graph to compare/contrast their impact on performance.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Plots(HashMap<String, Plot>);
+
+impl Plots {
+    pub fn new() -> Self {
+        Self(HashMap::new())
+    }
+
+    // Converts a list of deserialized Criterion benchmark results into a plotting-friendly format,
+    // and adds the data to the `Plots` struct.
+    pub fn add_data(&mut self, bench_data: &Vec<BenchData>) {
+        for bench in bench_data {
+            let commit_date = str_to_datetime(&bench.id.bench_name).expect("Timestamp parse error");
+            let point = Point {
+                x: commit_date,
+                y: bench.result.time,
+            };
+
+            if self.0.get(&bench.id.group_name).is_none() {
+                self.0.insert(bench.id.group_name.to_owned(), Plot::new());
+            }
+            let plot = self.0.get_mut(&bench.id.group_name).unwrap();
+
+            plot.x_axis.set_min_max(commit_date);
+            plot.y_axis.set_min_max(point.y);
+
+            if plot.lines.get(&bench.id.params).is_none() {
+                plot.lines.insert(bench.id.params.to_owned(), vec![]);
+            }
+            plot.lines.get_mut(&bench.id.params).unwrap().push(point);
+        }
+        // Sort each data point in each line for each plot
+        for plot in self.0.iter_mut() {
+            for line in plot.1.lines.iter_mut() {
+                line.1.sort_by(|a, b| a.partial_cmp(b).unwrap());
+            }
+        }
+    }
+}
+
+// The data type for a plot: contains the range of X and Y values, and the line(s) to be drawn
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Plot {
+    x_axis: XAxisRange,
+    y_axis: YAxisRange,
+    lines: HashMap<String, Vec<Point>>,
+}
+
+impl Plot {
+    pub fn new() -> Self {
+        Self {
+            x_axis: XAxisRange::default(),
+            y_axis: YAxisRange::default(),
+            lines: HashMap::new(),
+        }
+    }
+}
+
+// Historical benchmark result, showing the performance at a given Git commit
+#[derive(Debug, Serialize, Deserialize, PartialEq, PartialOrd)]
+pub struct Point {
+    // Commit timestamp associated with benchmark
+    x: DateTime<Utc>,
+    // Benchmark time (avg.)
+    y: f64,
+}
+
+// Min. and max. X axis values for a given plot
+#[derive(Debug, Serialize, Deserialize)]
+pub struct XAxisRange {
+    #[serde(with = "ts_seconds")]
+    min: DateTime<Utc>,
+    #[serde(with = "ts_seconds")]
+    max: DateTime<Utc>,
+}
+
+// Starts with flipped min/max so they can be set by `Point` values as they are encountered
+impl Default for XAxisRange {
+    fn default() -> Self {
+        Self {
+            min: Utc::now(),
+            max: chrono::DateTime::<Utc>::MIN_UTC,
+        }
+    }
+}
+
+// Min. and max. Y axis values for a given plot
+#[derive(Debug, Serialize, Deserialize)]
+pub struct YAxisRange {
+    min: f64,
+    max: f64,
+}
+
+// Starts with flipped min/max so they can be set by `Point` values as they are encountered
+impl Default for YAxisRange {
+    fn default() -> Self {
+        Self {
+            min: f64::MAX,
+            max: f64::MIN,
+        }
+    }
+}
+
+// Checks if input is < the current min and/or > current max
+// If so, sets input as the new min and/or max respectively
+trait MinMax<T: PartialOrd> {
+    fn set_min_max(&mut self, value: T);
+}
+
+impl MinMax<DateTime<Utc>> for XAxisRange {
+    fn set_min_max(&mut self, value: DateTime<Utc>) {
+        if value < self.min {
+            self.min = value
+        }
+        if value > self.max {
+            self.max = value
+        }
+    }
+}
+
+impl MinMax<f64> for YAxisRange {
+    fn set_min_max(&mut self, value: f64) {
+        if value < self.min {
+            self.min = value
+        }
+        if value > self.max {
+            self.max = value
+        }
+    }
+}


### PR DESCRIPTION
## Historical Benchmark Plots
This PR implements a `benchmark-plotter` crate, which turns Criterion benchmark JSON into historical plots deployed to `gh-pages`. It is comprised of the following:
- JSON deserializer in `src/json.rs` that extracts the plot-relevant data
- Plotting backend using https://github.com/plotters-rs/plotters
- Persistent `Plots` struct that saves historical results to disk for reuse
- `gh-pages` deployment action with some basic HTML to improve readability

## Caveats
- This is a PoC and should not be considered production-ready. There are several TODOs to address before using it in e.g. marketing material, chiefly visual improvements and incorporation into a SSG.
- The `plotters` configuration contains some hacks for visual clarity, so any usage downstream will likely need ad-hoc tweaks to the axes, units, and image scaling.
- See TODOs for more, e.g. crate structure in the `ci-workflows` repo

## Successful run
https://lurk-lab.github.io/ci-lab/benchmarks/history/plots.html
https://github.com/lurk-lab/ci-lab/actions/runs/7719349320/job/21042427254

> [!WARNING]
> Untested in its current form as a `ci-workflows` crate. Requires further testing once merged before use in downstream repos