### PR TITLE
fix: Run `cargo udeps` on all packages/targets

### DIFF
--- a/.github/workflows/unused-deps.yml
+++ b/.github/workflows/unused-deps.yml
@@ -33,7 +33,7 @@ jobs:
       # opt to use the stable toolchain specified via the 'rust-toolchain' file
       # and instead enable nightly features via 'RUSTC_BOOTSTRAP'
       - name: run cargo-udeps
-        run: RUSTC_BOOTSTRAP=1 cargo udeps --lib --features "${{ inputs.features }}"
+        run: RUSTC_BOOTSTRAP=1 cargo udeps --workspace --all-targets --features "${{ inputs.features }}"
       - uses: JasonEtco/create-an-issue@v2
         if: ${{ failure() }}
         env:


### PR DESCRIPTION
https://github.com/lurk-lab/lurk-rs/issues/1102 gives a false positive by only running `--lib`, so it thinks deps used in `src/main.rs` are unused. By running against all packages and targets we fix this and check the full set of dependency usage in the caller crate.