### PR TITLE
Fix `bench-deploy.yml` action

### DIFF
--- a/.github/workflows/bench-deploy.yml
+++ b/.github/workflows/bench-deploy.yml
@@ -3,7 +3,20 @@
 # - `gh-pages` branch with Pages deployment set up
 # - Ideally some HTML to link to the reports, e.g. https://lurk-lab.github.io/ci-lab/
 # - Self-hosted runner attached to the caller repo with `gpu-bench` and `gh-pages` tags
-# - `justfile` with a `gpu-bench-ci` recipe that outputs `<bench-name>-<short-sha>.json`
+# - `justfile` with a `gpu-bench-ci` recipe that outputs `<bench-name>-<short-commit-hash>.json`
+#
+# The core file structure is a `benchmarks/history` directory on the `gh-pages` branch that contains:
+# - Historical data `.tar.gz` archives, one for each commit or workflow run, which contain the Criterion benchmark results
+#   and `Cargo.lock` for the given commit.
+# - Historical data in `plot-data.json`, which contains only the relevant metadata and average benchmark result for each of
+#   the saved benchmarks. This file is persistent and append-only, and if it's not found then it is re-created using each of
+#   the `tar.gz` archives
+# - `.png` plot images, created on each run using `plot-data.json`
+# - HTML to render the images.
+#
+# This structure is all created/deployed by the workflow after running the benchmarks,
+# with the only prerequisite being an existing `gh-pages` branch deployed via GitHub Pages.
+# See https://github.com/lurk-lab/ci-lab/tree/gh-pages as an example of the deployed plots
 name: Deploy GPU benchmark from default branch
 
 on:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
+camino = "1.1.6"
 # chrono version is pinned to be compatible with plotters `build_cartesian_2d` API
 chrono = { version = "=0.4.20", features = ["clock", "serde"] }
+clap = { version = "4.5.1", features = ["derive"] }
 plotters = "0.3.5"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.111"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,35 +1,113 @@
+// This crate provides a CLI for plotting and managing historical Criterion benchmark files
+// It consists of the following commands:
+// - `cargo run plot` will plot the benchmark JSON file(s) at a given path. The bench files are required to be in the
+// `BenchOutputType::GhPages` format. See `BenchOutputType` for the different bench ID schemas.
+// TODO: below
+// - `cargo run convert` will convert benchmark JSONs to different formats for use in other tools.
+// E.g. `cargo run convert --input gh-pages --output commit-comment` will reformat the bench ID and other attributes,
+// which will enable the benchmark to be used with `criterion-table`.
+
+// NOTE: This tool is only intended for non-regression benchmarks, which compare performance for the *same* functions
+// between Git commits over time. In future we may generalize this crate for comparison between different functions.
+
 mod json;
 mod plot;
 
-use std::{
-    io::{self, Read, Write},
-    path::PathBuf,
-};
+use std::io::{self, Read, Write};
 
-use anyhow::anyhow;
+use camino::{Utf8Path, Utf8PathBuf};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use json::read_json_from_file;
 
-use crate::plot::{generate_plots, Plots};
+use crate::{
+    json::BenchData,
+    plot::{generate_plots, Plots},
+};
 
-// Benchmark files to plot, e.g. `LURK_BENCH_FILES=fibonacci-abc1234,fibonacci-def5678`
-fn bench_files_env() -> anyhow::Result<Vec<String>> {
-    std::env::var("LURK_BENCH_FILES")
-        .map_err(|e| anyhow!("Benchmark files env var isn't set: {e}"))
-        .and_then(|commits| {
-            let vec: anyhow::Result<Vec<String>> = commits
-                .split(',')
-                .map(|sha| {
-                    sha.parse::<String>()
-                        .map_err(|e| anyhow!("Failed to parse Git commit string: {e}"))
-                })
-                .collect();
-            vec
-        })
+/// Criterion benchmark JSON formatter & plotter
+#[derive(Parser, Debug)]
+#[clap(version, about, long_about = None)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Plot benchmark file(s)
+    Plot(PlotArgs),
+    /// Convert a benchmark file from one output format to another
+    Convert(ConvertArgs),
+}
+
+#[derive(Args, Debug)]
+struct PlotArgs {
+    #[clap(long, value_parser)]
+    dir: Option<Utf8PathBuf>,
+}
+
+impl PlotArgs {
+    fn create_plots(&self) {
+        // If existing plot data is found on disk, only read and add benchmark files specified by `LURK_BENCH_FILES`
+        // Data is stored in a `HashMap` so duplicates are ignored
+        let (mut plots, bench_files) = {
+            if let Ok(plots) = read_plots_from_file() {
+                // Adds all JSONs contained in `self.dir` to the plot
+                // Otherwise defaults to all files in workdir with current Git commit in the filename
+                let (dir, suffix) = if let Some(dir) = &self.dir {
+                    (dir.as_path(), None)
+                } else {
+                    let mut commit_hash = env!("VERGEN_GIT_SHA").to_owned();
+                    commit_hash.truncate(7);
+                    (Utf8Path::new("."), Some(commit_hash))
+                };
+                let bench_files =
+                    get_json_paths(dir, suffix.as_deref()).expect("Failed to read JSON paths");
+
+                (plots, bench_files)
+            }
+            // If no plot data exists, read all `JSON` files in the current directory and save to disk
+            else {
+                let paths = get_json_paths(&Utf8PathBuf::from("."), None)
+                    .expect("Failed to read JSON paths");
+                (Plots::new(), paths)
+            }
+        };
+        println!("Adding bench files to plot: {:?}", bench_files);
+        let mut bench_data = vec![];
+        for file in bench_files {
+            let mut data = read_json_from_file::<_, BenchData>(file).expect("JSON serde error");
+            bench_data.append(&mut data);
+        }
+        plots.add_data(&bench_data);
+
+        // Write to disk
+        write_plots_to_file(&plots).expect("Failed to write `Plots` to `plot-data.json`");
+        generate_plots(&plots).unwrap();
+    }
+}
+
+#[derive(Args, Debug)]
+struct ConvertArgs {
+    /// Bench format of the input
+    #[clap(long, value_enum)]
+    input: BenchOutputType,
+
+    /// Desired bench format of the output
+    #[clap(long, value_enum)]
+    output: BenchOutputType,
+}
+
+#[derive(Clone, Debug, ValueEnum)]
+enum BenchOutputType {
+    GhPages,
+    CommitComment,
+    PrComment,
 }
 
 // Deserializes JSON file into `Plots` type
 fn read_plots_from_file() -> Result<Plots, io::Error> {
-    let path = std::path::Path::new("plot-data.json");
+    let path = Utf8Path::new("plot-data.json");
 
     let mut file = std::fs::File::open(path)?;
 
@@ -43,7 +121,7 @@ fn read_plots_from_file() -> Result<Plots, io::Error> {
 
 // Serializes `Plots` type into file
 fn write_plots_to_file(plot_data: &Plots) -> Result<(), io::Error> {
-    let path = std::path::Path::new("plot-data.json");
+    let path = Utf8Path::new("plot-data.json");
 
     let mut file = std::fs::File::create(path)?;
 
@@ -52,17 +130,17 @@ fn write_plots_to_file(plot_data: &Plots) -> Result<(), io::Error> {
     file.write_all(json_data.as_bytes())
 }
 
-// TODO: Switch to camino
-// Gets all JSON paths in the current directory, optionally ending in a given suffix
+// Searches for all JSON paths in the specified directory, optionally ending in a given suffix
 // E.g. if `suffix` is `abc1234.json` it will return "*abc1234.json"
-fn get_json_paths(suffix: Option<&str>) -> std::io::Result<Vec<std::path::PathBuf>> {
+fn get_json_paths(dir: &Utf8Path, suffix: Option<&str>) -> std::io::Result<Vec<Utf8PathBuf>> {
     let suffix = suffix.unwrap_or(".json");
-    let entries = std::fs::read_dir(".")?
+    let entries = std::fs::read_dir(dir)?
         .flatten()
         .filter_map(|e| {
             let ext = e.path();
-            if ext.to_str()?.ends_with(suffix) {
-                Some(ext)
+            let ext = ext.to_str()?;
+            if ext.ends_with(suffix) && ext != "./plot-data.json" {
+                Some(Utf8PathBuf::from(ext))
             } else {
                 None
             }
@@ -72,43 +150,9 @@ fn get_json_paths(suffix: Option<&str>) -> std::io::Result<Vec<std::path::PathBu
 }
 
 fn main() {
-    // If existing plot data is found on disk, only read and add benchmark files specified by `LURK_BENCH_FILES`
-    // Data is stored in a `HashMap` so duplicates are ignored
-    let (mut plots, bench_files) = {
-        if let Ok(plots) = read_plots_from_file() {
-            // The user should know which files they just benchmarked and want to add to the plot
-            // Otherwise defaults to all files containing the current Git commit
-            let bench_files = bench_files_env().map_or_else(
-                |_| {
-                    let mut short_sha = env!("VERGEN_GIT_SHA").to_owned();
-                    short_sha.truncate(7);
-                    get_json_paths(Some(&format!("{}.json", short_sha)))
-                        .expect("Failed to read JSON paths")
-                },
-                |files| {
-                    files
-                        .iter()
-                        .map(|file| PathBuf::from(format!("{}.json", file)))
-                        .collect()
-                },
-            );
-            (plots, bench_files)
-        }
-        // If no plot data exists, read all `JSON` files in the current directory and save to disk
-        else {
-            let paths = get_json_paths(None).expect("Failed to read JSON paths");
-            (Plots::new(), paths)
-        }
+    let cli = Cli::parse();
+    match &cli.command {
+        Command::Plot(p) => p.create_plots(),
+        Command::Convert(_c) => todo!(),
     };
-    println!("Adding bench files to plot: {:?}", bench_files);
-    let mut bench_data = vec![];
-    for file in bench_files {
-        let mut data = read_json_from_file(file).expect("JSON serde error");
-        bench_data.append(&mut data);
-    }
-    plots.add_data(&bench_data);
-
-    // Write to disk
-    write_plots_to_file(&plots).expect("Failed to write `Plots` to `plot-data.json`");
-    generate_plots(&plots).unwrap();
 }

--- a/src/plot.rs
+++ b/src/plot.rs
@@ -7,8 +7,10 @@ use std::{collections::HashMap, error::Error};
 
 use crate::json::BenchData;
 
+// TODO: Plot throughput as well as timings
 pub fn generate_plots(data: &Plots) -> Result<(), Box<dyn Error>> {
     for plot in data.0.iter() {
+        println!("Plotting: {} {:?}", plot.0, plot.1);
         let out_file_name = format!("./{}.png", plot.0);
         let root = BitMapBackend::new(&out_file_name, (1024, 768)).into_drawing_area();
         root.fill(&WHITE)?;
@@ -92,7 +94,7 @@ fn style(idx: usize) -> PaletteColor<Palette99> {
 // saved to disk in `plot-data.json`, and is meant to be append-only to preserve historical results.
 //
 // Note:
-// Plots are separated by benchmark input e.g. `Fibonacci-num-100`. It doesn't reveal much
+// Plots are separated by benchmark group and function e.g. `Fibonacci-num=100-Prove`. It doesn't reveal much
 // information to view multiple benchmark input results on the same graph (e.g. fib-10 and fib-20),
 // since they are expected to be different. Instead, we group different benchmark parameters
 // (e.g. `rc` value) onto the same graph to compare/contrast their impact on performance.
@@ -114,11 +116,13 @@ impl Plots {
                 y: bench.result.time,
                 label: id.params.commit_hash.clone(),
             };
+            // plotters doesn't like `/` char in plot title so we use `-`
+            let plot_name = format!("{}-{}", id.group_name, id.bench_name);
 
-            if self.0.get(&id.group_name).is_none() {
-                self.0.insert(id.group_name.to_owned(), Plot::new());
+            if self.0.get(&plot_name).is_none() {
+                self.0.insert(plot_name.clone(), Plot::new());
             }
-            let plot = self.0.get_mut(&id.group_name).unwrap();
+            let plot = self.0.get_mut(&plot_name).unwrap();
 
             plot.x_axis.set_min_max(id.params.commit_timestamp);
             plot.y_axis.set_min_max(point.y);


### PR DESCRIPTION
## Changes
- Fixes deployment of historical benchmarks in caller repos
- Adds support for labeled points on the historical graph

## Overview
The following is meant to elucidate the current state of the historical plotting workflow for the benefit of reviewers and myself. It should evolve into inline or hosted documentation at some point.

### Historical plot data 
The core file structure is a `benchmarks/history` directory on the `gh-pages` branch that contains:
- Historical data `.tar.gz` archives, one for each commit or workflow run, which contain the Criterion benchmark results and `Cargo.lock` for the given commit.
- Historical data in `plot-data.json`, which contains only the relevant metadata and average benchmark result for each of the. This file is persistent and append-only, and if it's not found then it is re-created using each of the historical `.tar.gz` results.
- `.png` plot images, created on each run using `plot-data.json`
- HTML to render the images.
 
This is all created/deployed by the workflow after running the benchmarks, with the only prerequisite being an existing `gh-pages` branch deployed via GitHub Pages. See https://github.com/lurk-lab/ci-lab/tree/gh-pages and the `Successful run` below as an example

### Benchmark data format
This workflow expects a specific Criterion Benchmark ID format in order to parse and plot data correctly. The schema used by Criterion is as follows:
```
<bench_group>/<bench_name>/<bench_params>
```
This ID is then printed to stdout and stored in the resulting benchmark JSON, along with the bench results and other statistics.

For the purpose of `gh-pages` benchmarks, `bench_params` must be equivalent to `<commit_hash>-<commit_timestamp>-<params>`, so it will look like the following example in Lurk:
```
Fibonacci-num=10/Prove/dd2a8e6-2024-02-20T22:48:21-05:00-rc=100
```

When plotting, we split the data into the following groups:
- One plot per `bench_group`/`bench_name` pair, e.g. `Fibonacci-num=10-Prove`
- Each `(x, y)` coordinate is a pair of `(commit_timestamp, bench_result)`, optionally labeled with the `commit_hash`
- Each line of `(x, y)` coordinates is grouped by `bench_params`, e.g. one line each for `rc=100`, `rc=200`
 
A test plot can be viewed at https://lurk-lab.github.io/ci-lab/benchmarks/history/plots.html, though the data is still a WIP.

## Next steps
- Test with `lurk-rs` and `arecibo` once merged. This will require formatting `gh-pages` benchmarks properly using the ```<LURK|ARECIBO>_BENCH_OUTPUT``` env var and the new schema shown above. Also, this PR breaks plotting compatibility with old benchmarks so they will have to be manually moved to another directory (e.g. `benchmarks/history/deprecated`)
- JSON conversion script between `gh-pages` and `commit-comment` (see #52)
- Massage old JSON benchmark data to work with new benchmark data format. As seen in https://lurk-lab.github.io/ci-lab/benchmarks/history/plots.html, our old data doesn't follow the current data format and must be manually updated or deprecated. In my testing, updating old benchmark formats proved quite challenging due to the multiple old formats and attributes to change. More discussion is needed but I'm leaning toward archiving them for now and later extracting a simpler data set (similar to `plot-data.json) for plot integration.
- Switch plots from `.png` to `.svg` to enable zooming in/out

## Successful run
https://github.com/lurk-lab/ci-lab/actions/runs/8074420081/job/22060261452
https://lurk-lab.github.io/ci-lab/benchmarks/history/plots.html