### PR TITLE
Add `install-deps` action

### DIFF
--- a/.github/actions/install-deps/action.yml
+++ b/.github/actions/install-deps/action.yml
@@ -1,0 +1,14 @@
+name: Install dependencies
+
+description: Install Ubuntu prerequsite packages via `apt`
+
+inputs:
+  packages:
+    description: 'apt packages'
+    required: true
+
+runs:
+  using: "composite"
+  steps: 
+  - run: sudo apt-get update && sudo apt-get install -y ${{ inputs.packages }}
+    shell: bash

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -2,6 +2,11 @@ name: Check lints and code quality
 
 on:
   workflow_call:
+    inputs:
+      # List of prerequisite Ubuntu packages, separated by whitespace
+      packages:
+        required: false
+        type: string
 
 jobs:
   wasm-build:
@@ -11,6 +16,10 @@ jobs:
         with:
           repository: lurk-lab/ci-workflows
       - uses: ./.github/actions/ci-env
+      - uses: ./.github/actions/install-deps
+        if: inputs.packages != ''
+        with:
+          packages: "${{ inputs.packages }}"
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -28,6 +37,10 @@ jobs:
         with:
           repository: lurk-lab/ci-workflows
       - uses: ./.github/actions/ci-env
+      - uses: ./.github/actions/install-deps
+        if: inputs.packages != ''
+        with:
+          packages: "${{ inputs.packages }}"
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -54,6 +67,10 @@ jobs:
         with:
           repository: lurk-lab/ci-workflows
       - uses: ./.github/actions/ci-env
+      - uses: ./.github/actions/install-deps
+        if: inputs.packages != ''
+        with:
+          packages: "${{ inputs.packages }}"
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
Enables workflows to install prerequisite dependencies, which will allow us to fix [CI](https://github.com/lurk-lab/lurk-rs/actions/runs/8051573873/job/21989763496) for https://github.com/lurk-lab/lurk-rs/pull/1172

Successful run:
https://github.com/lurk-lab/ci-lab/actions/runs/8053253393/job/21995209009