### PR TITLE
chore: Refactor lints

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,4 +1,6 @@
-name: Check lints and code quality
+# NOTE: Does not currently work with Cargo workspaces
+# See https://github.com/lurk-lab/ci-workflows/issues/8
+name: Check MSRV
 
 on:
   workflow_call:
@@ -9,11 +11,9 @@ on:
         type: string
 
 jobs:
-  # Rustfmt, clippy, and doctests
-  lints:
+  # Check MSRV (aka `rust-version`) in `Cargo.toml` is valid
+  msrv:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,18 +25,8 @@ jobs:
           packages: "${{ inputs.packages }}"
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Check Rustfmt Code Style
-        run: |
-          cargo fmt --all -- --check
-      - name: Check clippy warnings
-        run: |
-          if $(cargo --list|grep -q xclippy); then 
-            cargo xclippy -Dwarnings
-          else 
-            cargo clippy -Dwarnings
-          fi
-      - name: Doctests
-        run: cargo test --doc --workspace
+      - name: Install cargo-msrv
+        run: cargo install cargo-msrv
+      - name: Check Rust MSRV
+        run: cargo msrv verify 

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,4 +1,4 @@
-name: Check lints and code quality
+name: Wasm build
 
 on:
   workflow_call:
@@ -7,13 +7,9 @@ on:
       packages:
         required: false
         type: string
-
 jobs:
-  # Rustfmt, clippy, and doctests
-  lints:
+  wasm-build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -25,18 +21,7 @@ jobs:
           packages: "${{ inputs.packages }}"
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      - name: Check Rustfmt Code Style
-        run: |
-          cargo fmt --all -- --check
-      - name: Check clippy warnings
-        run: |
-          if $(cargo --list|grep -q xclippy); then 
-            cargo xclippy -Dwarnings
-          else 
-            cargo clippy -Dwarnings
-          fi
-      - name: Doctests
-        run: cargo test --doc --workspace
+      - run: rustup target add wasm32-unknown-unknown
+      - name: Wasm build 
+        run: cargo build --target wasm32-unknown-unknown


### PR DESCRIPTION
Factors out the Wasm and MSRV checks from `lints.yml`, as we don't always want to run all three reusable workflows.