### PR TITLE
Remove conditional in `bench-pr-comment.yml`

### DIFF
--- a/.github/workflows/bench-pr-comment.yml
+++ b/.github/workflows/bench-pr-comment.yml
@@ -41,11 +41,6 @@ jobs:
   setup:
     name: Set up benchmark parameters
     runs-on: ubuntu-latest
-    if:
-      github.event.issue.pull_request
-      && github.event.issue.state == 'open'
-      && (contains(github.event.comment.body, '!benchmark') || contains(github.event.comment.body, '!gpu-benchmark'))
-      && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER')
     env:
       GPU_BENCHMARK: ${{ contains(github.event.comment.body, '!gpu-benchmark') }}
     outputs:


### PR DESCRIPTION
Closes #50 by letting callers decide when to trigger the `issue_comment` workflow. For example, in a private repo the `author_association` check can be elided as permissions aren't as much of a concern.