### PR TITLE
fix: Build the workspace before running Codecov

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Clean the workspace
         run: cargo llvm-cov clean --workspace
       - name: Build
-        run: cargo build --profile dev-ci
+        run: cargo build --workspace --release
       - name: Collect coverage data
         run: cargo llvm-cov nextest --lcov --output-path lcov.info --profile ci --release --workspace
       - name: Upload coverage data to codecov


### PR DESCRIPTION
This enables Codecov to fail fast on a build error, such as https://github.com/lurk-lab/lurk-rs/actions/runs/8196615616/job/22417205470