### PR TITLE
fix: `cuda` feature and env in `bench-pr-comment.yml`

### DIFF
--- a/.github/workflows/bench-pr-comment.yml
+++ b/.github/workflows/bench-pr-comment.yml
@@ -100,6 +100,10 @@ jobs:
           if [[ ${{ env.GPU_BENCHMARK }} = 'true' || $(echo $FEATURES | grep -s cuda) ]]; then
             echo "cuda=true" | tee -a $GITHUB_OUTPUT
             COMMAND="gpu-benchmark"
+            # Add the "cuda" feature if not already specified
+            if echo "$FEATURES" | grep -vq "cuda" 2>/dev/null; then
+              FEATURES="${FEATURES},cuda"
+            fi
           else
             COMMAND="benchmark"
           fi
@@ -122,12 +126,12 @@ jobs:
       - name: Set env vars
         run: |
           # Trims newlines that may arise from `$GITHUB_OUTPUT`
-          for var in ${{ inputs.default-env }}
+          for var in "${{ inputs.default-env }}"
           do
             echo "$(echo $var | tr -d '\n')" | tee -a $GITHUB_ENV
           done
           # Overrides default env vars with those specified in the `issue_comment` input if identically named
-          for var in ${{ needs.setup.outputs.env-vars }}
+          for var in "${{ needs.setup.outputs.env-vars }}"
           do
             echo "$(echo $var | tr -d '\n')" | tee -a $GITHUB_ENV
           done


### PR DESCRIPTION
- Ensures the `cuda` feature is set by the `!gpu-benchmark` command
- Hopefully addresses https://github.com/lurk-lab/ci-workflows/issues/55 by enclosing the env var in quotes. Before, the script was running:
```
for var in '
'
```
which would likely cause the `Invalid format: '\n'` error

## Successful runs
https://github.com/lurk-lab/ci-lab/pull/84

See [here](https://github.com/lurk-lab/ci-lab/actions/runs/8362068595/job/22891756312#step:12:63]) and [here](https://github.com/lurk-lab/ci-lab/actions/runs/8362068595/job/22891756312#step:12:128) for confirmation that the `cuda` feature is active.