### PR TITLE
Fix `bench-pr-comment.yml` env

### DIFF
--- a/.github/workflows/bench-pr-comment.yml
+++ b/.github/workflows/bench-pr-comment.yml
@@ -126,12 +126,12 @@ jobs:
       - name: Set env vars
         run: |
           # Trims newlines that may arise from `$GITHUB_OUTPUT`
-          for var in "${{ inputs.default-env }}"
+          for var in ${{ inputs.default-env }}
           do
             echo "$(echo $var | tr -d '\n')" | tee -a $GITHUB_ENV
           done
           # Overrides default env vars with those specified in the `issue_comment` input if identically named
-          for var in "${{ needs.setup.outputs.env-vars }}"
+          for var in ${{ needs.setup.outputs.env-vars }}
           do
             echo "$(echo $var | tr -d '\n')" | tee -a $GITHUB_ENV
           done


### PR DESCRIPTION
Env vars are currently not being set properly as they are interpreted as one string literal rather than a list of strings. This leads to downstream issues such as https://github.com/lurk-lab/arecibo/pull/381#issuecomment-2079134046.

The values expand to multiple strings properly by removing quotes.

Successful runs: https://github.com/lurk-lab/ci-lab/pull/88