### PR TITLE
fix: `ci-env` & `check-downstream-compiles` actions

### DIFF
--- a/.github/actions/check-downstream-compiles/action.yml
+++ b/.github/actions/check-downstream-compiles/action.yml
@@ -44,6 +44,7 @@ runs:
 
         shopt -s nullglob
         # Collect the `(path, package)` pairs for most subcrates in the upstream directory, regardless of whether they are workspace members
+        # Patch paths are absolute so they can be used in any Cargo.toml
         SUBCRATES=$(find ${{ github.workspace }}/${{ inputs.upstream-path }} \( -type d \( -name target -o -name examples -o -name tests -o -name cli \) -prune \) -o -name Cargo.toml -exec awk '/^\[package\]/{flag=1} flag && /name\s*=/ {gsub(/"/, "", $3); package=$3} /^\[[^p]/ && flag {exit} END{if(package != "") print FILENAME, package}' {} \; | sed 's|/Cargo.toml | |g')
         shopt -u nullglob
 
@@ -54,14 +55,28 @@ runs:
             subcrates[${pair[1]}]=${pair[0]}
         done <<< "$SUBCRATES"
 
-        # Write Git patches for each dependency used downstream
-        for file in $(find . -name Cargo.toml -not -path "./target/*"); do
-          !(grep -q "\[patch.'$URL']" $file) && printf "\n\n[patch.'$URL']\n" | tee -a $file
+        # Get list of Git patches for each dependency used downstream
+        for crate in $DEP_NAMES; do
+          crate_path="${subcrates[$crate]}"
+          echo "$crate = { path = \"$crate_path\" }" | tee -a patches.txt
+        done
 
-          for crate in $DEP_NAMES; do
-            crate_path="${subcrates[$crate]}"
-            echo "$crate = { path = \"$crate_path\" }" | tee -a $file
-          done
+        ESCAPED_URL=$(printf '%s\n' "$URL" | sed 's/[\/&]/\\&/g')
+
+        # Write patches to all Cargo.toml files in the directory
+        for file in $(find . -name Cargo.toml -not -path "./target/*"); do
+          # Add the `[patch]` section if it doesn't exist already, as duplicates aren't allowed
+          if ! grep -q "\[patch.'$URL'\]" $file; then
+            printf "\n\n[patch.'$URL']\n" >> $file
+          # If `[patch]` does exist, remove any duplicate keys before inserting patches
+          else
+            for crate in $DEP_NAMES; do
+              sed -i "/\[patch.'$ESCAPED_URL'\]/,/^$/ { /^$crate.*$/d }" $file
+            done
+          fi
+
+          # Append all patches after the `[patch.'ssh']` line
+          sed -i "/\[patch.'$ESCAPED_URL'\]/r patches.txt" $file
         done
     - name: Check downstream types don't break spectacularly
       shell: bash 

--- a/.github/actions/check-downstream-compiles/action.yml
+++ b/.github/actions/check-downstream-compiles/action.yml
@@ -24,6 +24,7 @@ inputs:
 runs:
   using: "composite"
   steps: 
+    # Assumes at least one dependency in the current workspace is used by the downstream crate
     - name: Patch Cargo.toml
       shell: bash
       working-directory: ${{ github.workspace }}/${{ inputs.downstream-path }}
@@ -33,9 +34,6 @@ runs:
         else
           URL=https://github.com/${{ github.repository }}
         fi
-
-        # Assumes at least one dependency in the current workspace is used by the downstream crate
-        printf "\n[patch.'$URL']\n" | tee -a Cargo.toml
 
         # Get a list of all upstream dependencies used by the downstream crate workspace
         # This is done by checking for each instance of `git = <upstream_url>` in any of the downstream `Cargo.toml` files
@@ -56,10 +54,15 @@ runs:
             subcrates[${pair[1]}]=${pair[0]}
         done <<< "$SUBCRATES"
 
-        # Write Git patches for each dependency used downstream
-        for crate in $DEP_NAMES; do
-          crate_path="${subcrates[$crate]}"
-          echo "$crate = { path = \"$crate_path\" }" | tee -a Cargo.toml
+        for file in $(find . -name Cargo.toml -not -path "./target/*"); do
+          # Write Git patches for each dependency used downstream
+
+          !(grep -q "\[patch.'$URL']" $file) && printf "\n\n[patch.'$URL']\n" | tee -a $file
+
+          for crate in $DEP_NAMES; do
+            crate_path="${subcrates[$crate]}"
+            echo "$crate = { path = \"$crate_path\" }" | tee -a $file
+          done
         done
     - name: Check downstream types don't break spectacularly
       shell: bash 

--- a/.github/actions/check-downstream-compiles/action.yml
+++ b/.github/actions/check-downstream-compiles/action.yml
@@ -54,9 +54,8 @@ runs:
             subcrates[${pair[1]}]=${pair[0]}
         done <<< "$SUBCRATES"
 
+        # Write Git patches for each dependency used downstream
         for file in $(find . -name Cargo.toml -not -path "./target/*"); do
-          # Write Git patches for each dependency used downstream
-
           !(grep -q "\[patch.'$URL']" $file) && printf "\n\n[patch.'$URL']\n" | tee -a $file
 
           for crate in $DEP_NAMES; do

--- a/.github/actions/ci-env/action.yml
+++ b/.github/actions/ci-env/action.yml
@@ -1,32 +1,35 @@
 name: CI env setup
 
-description: Set CI-related env vars
-
-env:
-  CARGO_TERM_COLOR: always
-  # Disable incremental compilation.
-  #
-  # Incremental compilation is useful as part of an edit-build-test-edit cycle,
-  # as it lets the compiler avoid recompiling code that hasn't changed. However,
-  # on CI, we're not making small edits; we're almost always building the entire
-  # project from scratch. Thus, incremental compilation on CI actually
-  # introduces *additional* overhead to support making future builds
-  # faster...but no future builds will ever occur in any given CI environment.
-  #
-  # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
-  # for details.
-  CARGO_INCREMENTAL: 0
-  # Allow more retries for network requests in cargo (downloading crates) and
-  # rustup (installing toolchains). This should help to reduce flaky CI failures
-  # from transient network timeouts or other issues.
-  CARGO_NET_RETRY: 10
-  RUSTUP_MAX_RETRIES: 10
-  # Don't emit giant backtraces in the CI logs.
-  RUST_BACKTRACE: short
-  RUSTFLAGS: -D warnings
+description: Set Rust env vars
 
 runs:
   using: "composite"
   steps: 
-  - run: echo "CI env vars set"
+  - run: |
+      echo "CARGO_TERM_COLOR=always" | tee -a $GITHUB_ENV
+
+      # Disable incremental compilation.
+      #
+      # Incremental compilation is useful as part of an edit-build-test-edit cycle,
+      # as it lets the compiler avoid recompiling code that hasn't changed. However,
+      # on CI, we're not making small edits; we're almost always building the entire
+      # project from scratch. Thus, incremental compilation on CI actually
+      # introduces *additional* overhead to support making future builds
+      # faster...but no future builds will ever occur in any given CI environment.
+      #
+      # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
+      # for details.
+      echo "CARGO_INCREMENTAL=0" | tee -a $GITHUB_ENV
+
+      # Allow more retries for network requests in cargo (downloading crates) and
+      # rustup (installing toolchains). This should help to reduce flaky CI failures
+      # from transient network timeouts or other issues.
+      echo "CARGO_NET_RETRY=10" | tee -a $GITHUB_ENV
+
+      echo "CARGO_MAX_RETRIES=10" | tee -a $GITHUB_ENV
+
+      # Don't emit giant backtraces in the CI logs.
+      echo "RUST_BACKTRACE=short" | tee -a $GITHUB_ENV
+
+      echo "RUSTFLAGS=-D warnings" | tee -a $GITHUB_ENV
     shell: bash


### PR DESCRIPTION
- `check-downstream-compiles`: Recursively writes Git patches to all `Cargo.toml` files in the directory rather than only the top level, which ensures any nested workspaces are patched correctly. Any redundant patching of subcrates is a no-op that emits a safely ignorable compiler warning.
- `ci-env`: Sets the `env` vars properly, via `$GITHUB_ENV` rather than the job-level `env` keyword. Only the former actually persists after the composite action completes, as seen [here](https://github.com/wormhole-foundation/wp1/actions/runs/9166085252/job/25201708077?pr=218#step:7:5).

Successful run:
https://github.com/wormhole-foundation/wp1/actions/runs/9177178661/job/25234166925