### PR TITLE
feat: Support multiple crates in `check-downstream-compiles`

### DIFF
--- a/.github/actions/check-downstream-compiles/action.yml
+++ b/.github/actions/check-downstream-compiles/action.yml
@@ -20,6 +20,11 @@ inputs:
     required: false
     default: false
     type: boolean
+  # Comma-separated list of crates to patch further down the dependency chain
+  more-paths:
+    description: 'Paths to further downstream'
+    required: false
+    type: string
 
 runs:
   using: "composite"
@@ -78,7 +83,38 @@ runs:
           # Append all patches after the `[patch.'ssh']` line
           sed -i "/\[patch.'$ESCAPED_URL'\]/r patches.txt" $file
         done
+
+        # If more crates were specified, patch them too
+        if [[ ! -z "${{ inputs.more-paths }}" ]]; then
+          for path in "${{ inputs.more-paths }}"; do
+            for file in $(find $path -name Cargo.toml -not -path "./target/*"); do
+              # Add the `[patch]` section if it doesn't exist already, as duplicates aren't allowed
+              if ! grep -q "\[patch.'$URL'\]" $file; then
+                printf "\n\n[patch.'$URL']\n" >> $file
+              # If `[patch]` does exist, remove any duplicate keys before inserting patches
+              else
+                for crate in $DEP_NAMES; do
+                  sed -i "/\[patch.'$ESCAPED_URL'\]/,/^$/ { /^$crate.*$/d }" $file
+                done
+              fi
+
+              # Append all patches after the `[patch.'ssh']` line
+              sed -i "/\[patch.'$ESCAPED_URL'\]/r patches.txt" $file
+            done
+          done
+        fi
     - name: Check downstream types don't break spectacularly
       shell: bash 
       working-directory: ${{ github.workspace }}/${{ inputs.downstream-path }}
-      run: cargo check --workspace --tests --benches --examples
+      run: |
+        cargo check --workspace --tests --benches --examples
+    - name: Check more downstream types don't break spectacularly
+      if: ${{ inputs.more-paths != '' }}
+      shell: bash 
+      working-directory: ${{ github.workspace }}
+      run: |
+        for path in "${{ inputs.more-paths }}"; do
+          cd $path
+          cargo check --workspace --tests --benches --examples
+          cd ${{ github.workspace }}
+        done


### PR DESCRIPTION
Optionally takes in the `more-paths` input, which will take the same Cargo.toml path patches for the initially patched crate and apply them to each specified crate further down the stack.

For example, https://github.com/lurk-lab/Plonky3/pull/6 shows:
- Plonky3 calls the downstream action and is the source of path patches
- Sphinx is the primary crate to be patched & checked, and saves its relevant patches to `patches.txt`
- Zk-light-clients is the secondary crate to be patched & check, which it does by simply writing the patches in `patches.txt` to each `Cargo.toml` file in the repo.
- More paths downstream of Sphinx could be specified, so long as they are checked out to a separate path in the caller repo.

> [!NOTE]
> This PR should be merged before https://github.com/lurk-lab/Plonky3/pull/6, as the latter currently depends on the `downstream-transitive` branch here.